### PR TITLE
Fix for onlyChild TypeError using PhantomJS

### DIFF
--- a/src/maquette.js
+++ b/src/maquette.js
@@ -612,7 +612,7 @@
         var onlyChild = arguments[childIndex];
         if (typeof onlyChild === "string") {
           text = onlyChild;
-        } else if (onlyChild.length === 1 && typeof onlyChild[0] === "string") {
+        } else if (onlyChild !== undefined && onlyChild.length === 1 && typeof onlyChild[0] === "string") {
           text = onlyChild[0];
         }
       } 


### PR DESCRIPTION
TypeError: undefined is not an object (evaluating 'onlyChild.length')