### PR TITLE
Use eventHandlerInterceptor provided in projectionOptions if defined

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -1088,13 +1088,15 @@ export let createMapping = <Source, Target>(
 export let createProjector = function(projectionOptions: ProjectionOptions): Projector {
   let projector: Projector;
   projectionOptions = applyDefaultProjectionOptions(projectionOptions);
-  projectionOptions.eventHandlerInterceptor = function(propertyName: string, functionPropertyArgument: Function) {
-    return function() {
-      // intercept function calls (event handlers) to do a render afterwards.
-      projector.scheduleRender();
-      return functionPropertyArgument.apply(this, arguments);
+  if (projectionOptions.eventHandlerInterceptor === undefined) {
+    projectionOptions.eventHandlerInterceptor = function(propertyName: string, functionPropertyArgument: Function) {
+      return function() {
+        // intercept function calls (event handlers) to do a render afterwards.
+        projector.scheduleRender();
+        return functionPropertyArgument.apply(this, arguments);
+      };
     };
-  };
+  }
   let renderCompleted = true;
   let scheduled: number;
   let stopped = false;

--- a/test/projector.ts
+++ b/test/projector.ts
@@ -149,4 +149,44 @@ describe('Projector', () => {
 
   });
 
+  it('uses a null eventHandlerInterceptor', () => {
+    let projector = createProjector({ eventHandlerInterceptor: null });
+    let parentElement = { appendChild: sinon.stub() };
+    let handleClick = sinon.stub();
+    let renderFunction = sinon.stub().returns(h('button', { onclick: handleClick }));
+    projector.append(parentElement as any, renderFunction);
+
+    let button = parentElement.appendChild.lastCall.args[0] as HTMLElement;
+    let evt = {};
+
+    expect(global.requestAnimationFrame).not.to.be.called;
+    expect(button.onclick).is.equal(undefined);
+    expect(handleClick).not.to.be.called;
+  });
+
+  it('uses a supplied eventHandlerInterceptor', () => {
+    var eventHandlerInterceptorCalledFlag = false;
+    var eventHandlerCalledFlag = false;
+    let eventHandlerInterceptor = function(propertyName: string, functionPropertyArgument: Function) {
+        eventHandlerInterceptorCalledFlag = true;
+        return function() {
+          eventHandlerCalledFlag = true;
+        }
+    }
+    let projector = createProjector({ eventHandlerInterceptor: eventHandlerInterceptor });
+    let parentElement = { appendChild: sinon.stub() };
+    let handleClick = sinon.stub();
+    let renderFunction = sinon.stub().returns(h('button', { onclick: handleClick }));
+    projector.append(parentElement as any, renderFunction);
+
+    let button = parentElement.appendChild.lastCall.args[0] as HTMLElement;
+    let evt = {};
+
+    button.onclick.apply(button, [evt]);
+
+    expect(eventHandlerInterceptorCalledFlag).is.equal(true);
+    expect(eventHandlerCalledFlag).is.equal(true);
+    expect(handleClick).not.to.be.called;
+  });
+
 });


### PR DESCRIPTION
Includes a change to maquette.ts and two unit tests that fail without the change. The change makes it possible for an application to supply an eventHandlerInterceptor or set it to null if event handling interception is not desired. 

See this comment for more details on the motivation for this change: https://github.com/AFASSoftware/maquette/issues/35#issuecomment-195805477

While I think this pull request is a substantial improvement in configurability to experiment with different ways to dispatch events (like supporting a "bind" property), I'm still not 100% satisfied with the change in relation to the meaning of setting eventHandlerInterceptor to "null". 

It might be argued that a null eventHandlerInterceptor should mean event handlers are still set in the DOM using the user-supplied functions but they just are not wrapped by an interceptor -- rather than the current behavior for null that event handlers are not set at all. But I expect that is not a big use case and I did not want to modify more of the code code which might have more of a performance impact. 

Here is where such a  bigger change would need to be made though if it was desired in the future:
https://github.com/AFASSoftware/maquette/blob/8849e235445cb7b24cfa40a91974cddcb5c8e68a/src/maquette.ts#L444

The possibility of  larger change, however, probably should not stand in the way of a smaller improvement in the current pull request.