### PR TITLE
Falsy keys may not work as expected after bind changes

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -621,7 +621,9 @@ let checkDistinguishable = function(childNodes: VNode[], indexToCheck: number, p
   if (childNode.vnodeSelector === '') {
     return; // Text nodes need not be distinguishable
   }
-  let key = childNode.properties ? (childNode.properties.key || childNode.properties.bind) : undefined;
+  let key = childNode.properties ?
+    (childNode.properties.key === undefined ? childNode.properties.key : childNode.properties.bind) :
+    undefined;
   if (!key) { // A key is just assumed to be unique
     for (let i = 0; i < childNodes.length; i++) {
       if (i !== indexToCheck) {

--- a/test/dom/children.ts
+++ b/test/dom/children.ts
@@ -84,6 +84,115 @@ describe('dom', function() {
       expect(div.children.length).to.equal(2);
     });
 
+    it('can distinguish between string keys when adding', () => {
+      let projection = dom.create(h('div', [
+          h('span', { key: 'one' }),
+          h('span', { key: 'three' })
+        ]));
+
+        let div = projection.domNode as HTMLDivElement;
+        expect(div.children.length).to.equal(3);
+        let firstSpan = div.children[0];
+        let secondSpan = div.children[1];
+
+        projection.update(h('div', [
+          h('span', { key: 'one' }),
+          h('span', { key: 'two' }),
+          h('span', { key: 'three' })
+        ]));
+
+        expect(div.childNodes.length).to.equal(3);
+        expect(div.childNodes[0]).to.equal(firstSpan);
+        expect(div.childNodes[2]).to.equal(secondSpan);
+    });
+
+    it('can distinguish between falsy keys when adding', () => {
+      let projection = dom.create(h('div', [
+          h('span', { key: 0 }),
+          h('span', { key: null })
+        ]));
+
+        let div = projection.domNode as HTMLDivElement;
+        expect(div.children.length).to.equal(3);
+        let firstSpan = div.children[0];
+        let secondSpan = div.children[1];
+
+        projection.update(h('div', [
+          h('span', { key: 0 }),
+          h('span', { key: false }),
+          h('span', { key: null })
+        ]));
+
+        expect(div.childNodes.length).to.equal(3);
+        expect(div.childNodes[0]).to.equal(firstSpan);
+        expect(div.childNodes[2]).to.equal(secondSpan);
+    });
+
+    it('can distinguish between string keys when deleting', () => {
+      let projection = dom.create(h('div', [
+          h('span', { key: 'one' }),
+          h('span', { key: 'two' }),
+          h('span', { key: 'three' })
+        ]));
+
+        let div = projection.domNode as HTMLDivElement;
+        expect(div.children.length).to.equal(3);
+        let firstSpan = div.children[0];
+        let thirdSpan = div.children[2];
+
+        projection.update(h('div', [
+          h('span', { key: 'one' }),
+          h('span', { key: 'three' })
+        ]));
+
+        expect(div.childNodes.length).to.equal(2);
+        expect(div.childNodes[0]).to.equal(firstSpan);
+        expect(div.childNodes[1]).to.equal(thirdSpan);
+    });
+
+    it('can distinguish between falsy keys when deleting', () => {
+      let projection = dom.create(h('div', [
+          h('span', { key: 0 }),
+          h('span', { key: false }),
+          h('span', { key: null })
+        ]));
+
+        let div = projection.domNode as HTMLDivElement;
+        expect(div.children.length).to.equal(3);
+        let firstSpan = div.children[0];
+        let thirdSpan = div.children[2];
+
+        projection.update(h('div', [
+          h('span', { key: 0 }),
+          h('span', { key: null })
+        ]));
+
+        expect(div.childNodes.length).to.equal(2);
+        expect(div.childNodes[0]).to.equal(firstSpan);
+        expect(div.childNodes[1]).to.equal(thirdSpan);
+    });
+
+    it('does not reorder nodes based on keys', () => {
+      let projection = dom.create(h('div', [
+          h('span', { key: 'a' }),
+          h('span', { key: 'b' })
+        ]));
+
+        let div = projection.domNode as HTMLDivElement;
+        expect(div.children.length).to.equal(2);
+        let firstSpan = div.children[0];
+        let lastSpan = div.children[1];
+
+        projection.update(h('div', [
+          h('span', { key: 'b' }),
+          h('span', { key: 'a' })
+        ]));
+
+        expect(div.childNodes.length).to.equal(2);
+        expect(div.childNodes[1]).to.not.equal(firstSpan);
+        expect(div.childNodes[0]).to.equal(lastSpan);
+    });
+
     it('can insert textnodes', () => {
       let projection = dom.create(h('div', [
         h('span', { key: 2 }),


### PR DESCRIPTION
After the bind improvements, this [line of code](https://github.com/AFASSoftware/maquette/blob/3933f12460000bcfa240aa1c16b110a0eb64e242/src/maquette.ts#L624) in checkDistinguishable now reads:
`let key = childNode.properties ? (childNode.properties.key || childNode.properties.bind) : undefined;`

It [used to be](https://github.com/AFASSoftware/maquette/blob/8849e235445cb7b24cfa40a91974cddcb5c8e68a/src/maquette.ts#L606):
`let key = childNode.properties ? childNode.properties.key : undefined;`

The difference may seem small, but the behavior of [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) keys has changed. I would expect Maquette can no longer distinguish, say, between keys that are zero and the empty string. And presumably some existing application code may be broken by this change. I created unit tests to show that -- however they seem to be failing even with the patch below, so something else may be going on I don't understand.

Beyond more unit tests for children.ts, in the pull request, I changed the comparison in checkDistinguishable to:
```
let key = childNode.properties ? 
    (childNode.properties.key === undefined ? childNode.properties.key : childNode.properties.bind) : 
    undefined;
```

I'd normally say not to nest ternary operators and to use a separate variable for clarity, but as this is performance critical, the construct above may be OK. On the other hand, caching childNode.properties in a variable might be beneficial depending on how the underlying code optimizer works in any JavaScript VM. Again, as with the new issue on performance regressions, it would be good to know the impact of this change.

However, this change is not enough to make all the new unit tests pass. So, this is a puzzle for you. :-) Are the new unit tests wrong? Is something else acting unexpectedly?

BTW, my [comment in this other issue](https://github.com/AFASSoftware/maquette/issues/35#issuecomment-196596554) relates to this general issue. To help resolve this, you might want to review the rest of the Maquette code's use of `||` with this falsy issue in mind. In JavaScript application code that operator often works as expected, but the implications in library code of logical or can be more more complicated as above since they can affect the meaning of APIs.