### PR TITLE
Set type attribute on HtmlInputElements for <=IE8

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -760,6 +760,9 @@ createDom = function(vnode, parentNode, insertBefore, projectionOptions) {
             domNode = vnode.domNode = document.createElementNS(projectionOptions.namespace, found);
           } else {
             domNode = vnode.domNode = document.createElement(found);
+            if (found === 'input' && vnode.properties && vnode.properties.type !== undefined) { // IE8 and older don't support setting input type after it has been added to the document
+              domNode.setAttribute("type", vnode.properties.type);
+            }
           }
           if (insertBefore !== undefined) {
             parentNode.insertBefore(domNode, insertBefore);

--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -295,6 +295,7 @@ export interface VNodeProperties {
   accessKey?: string;
   id?: string;
   // From HTMLInputElement
+  type?: string;
   autocomplete?: string;
   checked?: boolean;
   placeholder?: string;
@@ -760,8 +761,9 @@ createDom = function(vnode, parentNode, insertBefore, projectionOptions) {
             domNode = vnode.domNode = document.createElementNS(projectionOptions.namespace, found);
           } else {
             domNode = vnode.domNode = document.createElement(found);
-            if (found === 'input' && vnode.properties && vnode.properties.type !== undefined) { // IE8 and older don't support setting input type after it has been added to the document
-              domNode.setAttribute("type", vnode.properties.type);
+            if (found === 'input' && vnode.properties && vnode.properties.type !== undefined) {
+              // IE8 and older don't support setting input type after the DOM Node has been added to the document
+              (domNode as Element).setAttribute("type", vnode.properties.type);
             }
           }
           if (insertBefore !== undefined) {

--- a/test/dom/properties.ts
+++ b/test/dom/properties.ts
@@ -105,6 +105,16 @@ describe('dom', function() {
       projection.update(h('div', { scrollTop: 1 }));
     });
 
+    it('sets HTMLInputElement.type before the element is added to the DOM for IE8 and earlier', () => {
+      let parentNode = {
+        appendChild: sinon.spy((child: HTMLElement) => {
+          expect(child.getAttribute('type')).to.equal('file');
+        })
+      }
+      let projection = dom.append(<any>parentNode, h('input', { type: 'file' }));
+      expect(parentNode.appendChild).to.have.been.called;
+    });
+
     describe('event handlers', () => {
 
       it('allows one to correct the value while being typed', () => {


### PR DESCRIPTION
IE8 and older don't support setting input type after it has been added to the document.

Fix: set the "type" attribute on a HtmlInputElement before it is appended to the document.

Example
```javascript
h("input", {type:"hidden", value:"test"})
```