### PR TITLE
Maquette should be able to remove disabled attribute when updating Node

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -551,7 +551,7 @@ let updateProperties = function(domNode: Node, previousProperties: VNodeProperti
         }
       }
     } else {
-      if (!propValue && typeof previousValue === 'string') {
+      if (!propValue && propName !== "disabled" && typeof previousValue === 'string') {
         propValue = '';
       }
       if (propName === 'value') { // value can be manipulated by the user directly and using event.preventDefault() is not an option
@@ -576,7 +576,11 @@ let updateProperties = function(domNode: Node, previousProperties: VNodeProperti
           }
         } else {
           if ((domNode as any)[propName] !== propValue) { // Comparison is here for side-effects in Edge with scrollLeft and scrollTop
-            (domNode as any)[propName] = propValue;
+            if (!propValue && propName === "disabled") {
+              (domNode as any).removeAttribute(propName);
+            } else {
+              (domNode as any)[propName] = propValue;
+            }
           }
         }
         propertiesUpdated = true;

--- a/test/dom/properties.ts
+++ b/test/dom/properties.ts
@@ -73,6 +73,15 @@ describe('dom', function() {
       expect(link.getAttribute('href')).to.equal('#2');
     });
 
+    it('can remove disabled attribute when null or undefined', () => {
+      let projection = dom.create(h('a', { disabled: 'disabled' }));
+      let link = projection.domNode as HTMLLinkElement;
+      expect(link.getAttribute('disabled')).to.equal('disabled');
+
+      projection.update(h('a', { disabled: null }));
+      expect(link.getAttribute('disabled')).to.not.exist;
+    });
+
     it('updates properties', () => {
       let projection = dom.create(h('a', { href: '#1', tabIndex: 1 }));
       let link = projection.domNode as HTMLLinkElement;


### PR DESCRIPTION
Hello,

I noticed recently that Maquette does not remove the `disabled` property from a dom Node.  Rule #2 in the [3 Rules of Maquette docs](http://maquettejs.org/tutorial/10-distinguishable.html) states:

> to clear the tabIndex attribute, you need to use either h("div", {tabIndex:undefined}), h("div", {tabIndex:null}) or h("div", {tabIndex:""}).

Maquette *does* clear the state of `disabled` but it does not remove it.
The [HTML spec(s)](http://stackoverflow.com/questions/6961526/correct-value-for-disabled-attribute/24579932#24579932) state:

> the absence of the attribute represents the false value.
> 
> If the attribute is present, its value must either be the empty string...

Therefore I believe the correct behavior for Maquette is to unset the `disabled` attribute when it receives `null` or `undefined`, however for an empty string `disabled` should still be set.

I am first pushing the test, to show failure in this case.  Then pushing the fix as a separate commit.

Thanks for your work, Maquette has been great!