### PR TITLE
fix a few typos in comments, childNodes/childnodes -> child nodes

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -23,7 +23,7 @@ export interface VNode {
    */
   readonly children: Array<VNode> | undefined;
   /**
-   * Used in a special case when a [[VNode]] only has one childnode which is a textnode. Only used in combination with children === undefined.
+   * Used in a special case when a [[VNode]] only has one child node which is a text node. Only used in combination with children === undefined.
    */
   readonly text: string | undefined;
   /**
@@ -48,9 +48,9 @@ export interface VNode {
  */
 export interface Projector {
   /**
-   * Appends a new childnode to the DOM using the result from the provided `renderMaquetteFunction`.
+   * Appends a new child node to the DOM using the result from the provided `renderMaquetteFunction`.
    * The `renderMaquetteFunction` will be invoked again to update the DOM when needed.
-   * @param parentNode - The parent node for the new childNode.
+   * @param parentNode - The parent node for the new child node.
    * @param renderMaquetteFunction - Function with zero arguments that returns a [[VNode]] tree.
    */
   append(parentNode: Element, renderMaquetteFunction: () => VNode): void;
@@ -66,7 +66,7 @@ export interface Projector {
    * This means that the virtual DOM and real DOM have one overlapping element.
    * Therefore the selector for the root [[VNode]] will be ignored, but its properties and children will be applied to the Element provided
    * The `renderMaquetteFunction` will be invoked again to update the DOM when needed.
-   * @param domNode - The existing element to adopt as the root of the new virtual DOM. Existing attributes and childnodes are preserved.
+   * @param domNode - The existing element to adopt as the root of the new virtual DOM. Existing attributes and child nodes are preserved.
    * @param renderMaquetteFunction - Function with zero arguments that returns a [[VNode]] tree.
    */
   merge(domNode: Element, renderMaquetteFunction: () => VNode): void;
@@ -128,7 +128,7 @@ export interface TransitionStrategy {
   /**
    * Function that is called when a [[VNode]] with an `exitAnimation` string is removed from a existing parent [[VNode]] that remains.
    *
-   * @param element         Element that ought to be removed from to the DOM.
+   * @param element         Element that ought to be removed from the DOM.
    * @param properties      The properties object that was supplied to the [[h]] method that rendered this [[VNode]] the previous time.
    * @param exitAnimation   The string that was passed to [[VNodeProperties.exitAnimation]].
    * @param removeElement   Function that removes the element from the DOM.
@@ -219,10 +219,10 @@ export interface VNodeProperties {
    */
   updateAnimation?: (element: Element, properties?: VNodeProperties, previousProperties?: VNodeProperties) => void;
   /**
-   * Callback that is executed after this node is added to the DOM. Childnodes and properties have
+   * Callback that is executed after this node is added to the DOM. Child nodes and properties have
    * already been applied.
    * @param element - The element that was added to the DOM.
-   * @param projectionOptions - The projection options that were used see [[createProjector]].
+   * @param projectionOptions - The projection options that were used, see [[createProjector]].
    * @param vnodeSelector - The selector passed to the [[h]] function.
    * @param properties - The properties passed to the [[h]] function.
    * @param children - The children that were created.
@@ -230,10 +230,10 @@ export interface VNodeProperties {
   afterCreate?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
     children: VNode[]): void;
   /**
-   * Callback that is executed every time this node may have been updated. Childnodes and properties
+   * Callback that is executed every time this node may have been updated. Child nodes and properties
    * have already been updated.
    * @param element - The element that may have been updated in the DOM.
-   * @param projectionOptions - The projection options that were used see [[createProjector]].
+   * @param projectionOptions - The projection options that were used, see [[createProjector]].
    * @param vnodeSelector - The selector passed to the [[h]] function.
    * @param properties - The properties passed to the [[h]] function.
    * @param children - The children for this node.
@@ -317,7 +317,7 @@ export interface VNodeProperties {
   readonly alt?: string;
   readonly srcset?: string;
   /**
-   * Puts a non-interactive piece of html inside the DOM node.
+   * Puts a non-interactive string of html inside the DOM node.
    *
    * Note: if you use innerHTML, maquette cannot protect you from XSS vulnerabilities and you must make sure that the innerHTML value is safe.
    */
@@ -948,9 +948,9 @@ export let dom = {
   },
 
   /**
-   * Appends a new childnode to the DOM which is generated from a [[VNode]].
+   * Appends a new child node to the DOM which is generated from a [[VNode]].
    * This is a low-level method. Users will typically use a [[Projector]] instead.
-   * @param parentNode - The parent node for the new childNode.
+   * @param parentNode - The parent node for the new child node.
    * @param vnode - The root of the virtual DOM tree that was created using the [[h]] function. NOTE: [[VNode]]
    * objects may only be rendered once.
    * @param projectionOptions - Options to be used to create and update the [[Projection]].
@@ -982,7 +982,7 @@ export let dom = {
    * This means that the virtual DOM and the real DOM will have one overlapping element.
    * Therefore the selector for the root [[VNode]] will be ignored, but its properties and children will be applied to the Element provided.
    * This is a low-level method. Users wil typically use a [[Projector]] instead.
-   * @param element - The existing element to adopt as the root of the new virtual DOM. Existing attributes and childnodes are preserved.
+   * @param element - The existing element to adopt as the root of the new virtual DOM. Existing attributes and child nodes are preserved.
    * @param vnode - The root of the virtual DOM tree that was created using the [[h]] function. NOTE: [[VNode]] objects
    * may only be rendered once.
    * @param projectionOptions - Options to be used to create and update the projection, see [[createProjector]].


### PR DESCRIPTION
Noticed a few typos during a review for Dojo 2, also thought using child nodes over inconsistent childnodes/childNodes/child nodes for the documentation for humans was a good idea, though could be persuaded that it should always be childNodes to match the variable name, but should pick one over the other and probably not childnodes. :)