### PR TITLE
Add a beforeRemove hook

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -241,6 +241,16 @@ export interface VNodeProperties {
   afterUpdate?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
     children: VNode[]): void;
   /**
+   * Callback that is executed before a node is removed from the DOM.
+   * @param element - The element that is about to be removed from the DOM.
+   * @param projectionOptions - The projection options that were used, see [[createProjector]].
+   * @param vnodeSelector - The selector passed to the [[h]] function.
+   * @param properties - The properties passed to the [[h]] function.
+   * @param children - The children for this node.
+   */
+  beforeRemove?(element: Element, projectionOptions: ProjectionOptions, vnodeSelector: string, properties: VNodeProperties,
+    children: VNode[]): void;
+  /**
    * When specified, the event handlers will be invoked with 'this' pointing to the value.
    * This is useful when using the prototype/class based implementation of Components.
    *
@@ -605,7 +615,8 @@ let findIndexOfChild = function(children: VNode[], sameAs: VNode, start: number)
   return -1;
 };
 
-let nodeAdded = function(vNode: VNode, transitions: TransitionStrategy) {
+let nodeAdded = function(vNode: VNode, projectionOptions: ProjectionOptions) {
+  let transitions: TransitionStrategy = projectionOptions.transitions!;
   if (vNode.properties) {
     let enterAnimation = vNode.properties.enterAnimation;
     if (enterAnimation) {
@@ -618,9 +629,14 @@ let nodeAdded = function(vNode: VNode, transitions: TransitionStrategy) {
   }
 };
 
-let nodeToRemove = function(vNode: VNode, transitions: TransitionStrategy) {
+let nodeToRemove = function(vNode: VNode, projectionOptions: ProjectionOptions) {
+  let transitions: TransitionStrategy = projectionOptions.transitions!;
   let domNode: Node = vNode.domNode!;
   if (vNode.properties) {
+    let beforeRemove = vNode.properties.beforeRemove;
+    if (beforeRemove) {
+      beforeRemove.apply(vNode.properties.bind || vNode.properties, [<Element>domNode, projectionOptions, vNode.vnodeSelector, vNode.properties, vNode.children]);
+    }
     let exitAnimation = vNode.properties.exitAnimation;
     if (exitAnimation) {
       (domNode as HTMLElement).style.pointerEvents = 'none';
@@ -679,8 +695,6 @@ let updateChildren = function(vnode: VNode, domNode: Node, oldChildren: VNode[] 
   newChildren = newChildren || emptyArray;
   let oldChildrenLength = oldChildren.length;
   let newChildrenLength = newChildren.length;
-  let transitions = projectionOptions.transitions!;
-
   let oldIndex = 0;
   let newIndex = 0;
   let i: number;
@@ -696,7 +710,7 @@ let updateChildren = function(vnode: VNode, domNode: Node, oldChildren: VNode[] 
       if (findOldIndex >= 0) {
         // Remove preceding missing children
         for (i = oldIndex; i < findOldIndex; i++) {
-          nodeToRemove(oldChildren[i], transitions);
+          nodeToRemove(oldChildren[i], projectionOptions);
           checkDistinguishable(oldChildren, i, vnode, 'removed');
         }
         textUpdated = updateDom(oldChildren[findOldIndex], newChild, projectionOptions) || textUpdated;
@@ -704,7 +718,7 @@ let updateChildren = function(vnode: VNode, domNode: Node, oldChildren: VNode[] 
       } else {
         // New child
         createDom(newChild, domNode, (oldIndex < oldChildrenLength) ? oldChildren[oldIndex].domNode : undefined, projectionOptions);
-        nodeAdded(newChild, transitions);
+        nodeAdded(newChild, projectionOptions);
         checkDistinguishable(newChildren, newIndex, vnode, 'added');
       }
     }
@@ -713,7 +727,7 @@ let updateChildren = function(vnode: VNode, domNode: Node, oldChildren: VNode[] 
   if (oldChildrenLength > oldIndex) {
     // Remove child fragments
     for (i = oldIndex; i < oldChildrenLength; i++) {
-      nodeToRemove(oldChildren[i], transitions);
+      nodeToRemove(oldChildren[i], projectionOptions);
       checkDistinguishable(oldChildren, i, vnode, 'removed');
     }
   }

--- a/test/dom/beforeRemove.ts
+++ b/test/dom/beforeRemove.ts
@@ -1,0 +1,31 @@
+import {expect, jsdom, sinon} from '../utilities';
+import {h, dom} from '../../src/maquette';
+
+describe('dom', () => {
+
+  jsdom();
+
+  describe('beforeRemove', () => {
+
+    it('is invoked before a node is removed from the dom', () => {
+      let beforeRemove = sinon.stub();
+      let projection = dom.create(h('div', {}, [
+        h('span', { beforeRemove })
+      ]));
+      projection.update(h('div', {}, []));
+      expect(beforeRemove).to.have.been.calledOnce;
+    });
+
+    it('is invoked with "this" set to the value of the bind property', () => {
+      let beforeRemove = sinon.stub();
+      let thisObject = sinon.stub();
+      let projection = dom.create(h('div', {}, [
+        h('span', { beforeRemove, bind: thisObject })
+      ]));
+      projection.update(h('div', {}, []));
+      expect(beforeRemove).to.be.calledOn(thisObject);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is more of a feature proposal than anything (although I wrote the code anyway). 

With the current hooks (`eventHandlerIntercepter` on `ProjectorOptions`, `afterCreate` and `afterUpdate` on a `VNode`), its possible to attach/associate things to a domNode. It would be nice to be able to teardown attached/associated things when the domNode is about to be removed. 

Although this functionality is partially available when using transitions with `exitTransition` it seems like it would be nice to make this a genuine hook like `afterCreate`.

Interested to hear your thoughts, thanks again!