### PR TITLE
Use .ownerDocument instead of global document

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -752,8 +752,9 @@ let initPropertiesAndChildren = function(domNode: Node, vnode: VNode, projection
 createDom = function(vnode, parentNode, insertBefore, projectionOptions) {
   let domNode: Node | undefined, i: number, c: string, start = 0, type: string, found: string;
   let vnodeSelector = vnode.vnodeSelector;
+  let doc = parentNode.ownerDocument;
   if (vnodeSelector === '') {
-    domNode = vnode.domNode = document.createTextNode(vnode.text!);
+    domNode = vnode.domNode = doc.createTextNode(vnode.text!);
     if (insertBefore !== undefined) {
       parentNode.insertBefore(domNode, insertBefore);
     } else {
@@ -774,9 +775,9 @@ createDom = function(vnode, parentNode, insertBefore, projectionOptions) {
             projectionOptions = extend(projectionOptions, { namespace: NAMESPACE_SVG });
           }
           if (projectionOptions.namespace !== undefined) {
-            domNode = vnode.domNode = document.createElementNS(projectionOptions.namespace, found);
+            domNode = vnode.domNode = doc.createElementNS(projectionOptions.namespace, found);
           } else {
-            domNode = vnode.domNode = document.createElement(found);
+            domNode = vnode.domNode = doc.createElement(found);
             if (found === 'input' && vnode.properties && vnode.properties.type !== undefined) {
               // IE8 and older don't support setting input type after the DOM Node has been added to the document
               (domNode as Element).setAttribute("type", vnode.properties.type);
@@ -804,7 +805,7 @@ updateDom = function(previous, vnode, projectionOptions) {
   let updated = false;
   if (vnode.vnodeSelector === '') {
     if (vnode.text !== previous.text) {
-      let newVNode = document.createTextNode(vnode.text!);
+      let newVNode = domNode.ownerDocument.createTextNode(vnode.text!);
       domNode.parentNode!.replaceChild(newVNode, domNode);
       vnode.domNode = newVNode;
       textUpdated = true;

--- a/test/dom/properties.ts
+++ b/test/dom/properties.ts
@@ -127,10 +127,16 @@ describe('dom', function() {
       let parentNode = {
         appendChild: sinon.spy((child: HTMLElement) => {
           expect(child.getAttribute('type')).to.equal('file');
-        })
+        }),
+        ownerDocument: {
+          createElement: sinon.spy((tag: string) => {
+            return document.createElement(tag);
+          })
+        }
       }
       let projection = dom.append(<any>parentNode, h('input', { type: 'file' }));
       expect(parentNode.appendChild).to.have.been.called;
+      expect(parentNode.ownerDocument.createElement).to.have.been.called;
     });
 
     describe('event handlers', () => {

--- a/test/projector.ts
+++ b/test/projector.ts
@@ -19,6 +19,11 @@ describe('Projector', () => {
     let parentElement = {
       appendChild: sinon.stub(),
       insertBefore: sinon.stub(),
+      ownerDocument: {
+        createElement: sinon.spy((tag: string) => {
+          return document.createElement(tag);
+        })
+      },
       removeChild: sinon.stub()
     };
     let renderFunction = sinon.stub().returns(
@@ -32,6 +37,7 @@ describe('Projector', () => {
     projector.append(parentElement as any, renderFunction);
 
     expect(renderFunction).to.have.been.calledOnce;
+    expect(parentElement.ownerDocument.createElement).to.have.been.calledOnce;
     expect(parentElement.appendChild).to.have.been.calledOnce;
     expect(parentElement.appendChild.lastCall.args[0]).to.deep.include({ tagName: 'DIV' });
 
@@ -49,12 +55,18 @@ describe('Projector', () => {
 
     // Merge
     let existingElement = {
-      appendChild: sinon.stub()
+      appendChild: sinon.stub(),
+      ownerDocument: {
+        createElement: sinon.spy((tag: string) => {
+          return document.createElement(tag);
+        })
+      }
     };
 
     projector.merge(existingElement as any, renderFunction);
 
     expect(renderFunction).to.have.been.calledThrice;
+    expect(existingElement.ownerDocument.createElement).to.have.been.calledOnce;
     expect(existingElement.appendChild).to.have.been.calledOnce;
     expect(existingElement.appendChild.lastCall.args[0]).to.deep.include({ tagName: 'SPAN' });
 
@@ -68,6 +80,7 @@ describe('Projector', () => {
     expect(renderFunction).to.have.callCount(4);
     expect(parentElement.removeChild).to.have.been.calledOnce;
     expect(parentElement.removeChild.lastCall.args[0]).to.equal(oldElement);
+    expect(parentElement.ownerDocument.createElement).to.have.been.calledThrice;
     expect(parentElement.insertBefore).to.have.been.calledTwice;
     expect(parentElement.insertBefore.lastCall.args[0]).to.deep.include({ tagName: 'DIV' });
     expect(parentElement.insertBefore.lastCall.args[1]).to.equal(oldElement);
@@ -107,7 +120,7 @@ describe('Projector', () => {
 
   it('Stops when an error during rendering is encountered', () => {
     let projector = createProjector({});
-    let parentElement = { appendChild: sinon.stub() };
+    let parentElement = { appendChild: sinon.stub(), ownerDocument: document };
     let renderFunction = sinon.stub().returns(h('div'));
     projector.append(parentElement as any, renderFunction);
     renderFunction.throws('Rendering error');
@@ -132,7 +145,7 @@ describe('Projector', () => {
 
   it('schedules a render when event handlers are called', () => {
     let projector = createProjector({});
-    let parentElement = { appendChild: sinon.stub() };
+    let parentElement = { appendChild: sinon.stub(), ownerDocument: document };
     let handleClick = sinon.stub();
     let renderFunction = () => h('button', { onclick: handleClick });
     projector.append(parentElement as any, renderFunction);
@@ -150,7 +163,7 @@ describe('Projector', () => {
   });
 
   it('invokes the eventHandler with "this" set to the DOM node when no bind is present', () => {
-    let parentElement = { appendChild: sinon.stub() };
+    let parentElement = { appendChild: sinon.stub(), ownerDocument: document };
     let projector = createProjector({});
     let handleClick = sinon.stub();
     let renderFunction = () => h('button', { onclick: handleClick });
@@ -191,7 +204,7 @@ describe('Projector', () => {
     let clicked = sinon.stub();
     let button = new ButtonComponent('Click me', clicked);
 
-    let parentElement = { appendChild: sinon.stub() };
+    let parentElement = { appendChild: sinon.stub(), ownerDocument: document };
     let projector = createProjector({});
     projector.append(parentElement as any, () => button.renderMaquette());
 
@@ -203,7 +216,7 @@ describe('Projector', () => {
   });
 
   it('can detach a projection', () => {
-    let parentElement = { appendChild: sinon.stub() };
+    let parentElement = { appendChild: sinon.stub(), ownerDocument: document };
     let projector = createProjector({});
     let renderFunction = () => h('textarea#t1');
     let renderFunction2 = () => h('textarea#t2');


### PR DESCRIPTION
This PR utilises `.ownerDocument` in situations where the global `document` is referenced (with the exception of `create()` where `document` is still referenced.  When working in multi-document contexts, this will ensure that the proper document is used as well as making it easier to use `maquette` for server side rendering by not requiring a global `document` to be exposed.

Resolves #96 