### PR TITLE
Allow DOM nodes to be reused with projector.merge

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -734,7 +734,11 @@ let addChildren = function(domNode: Node, children: VNode[] | undefined, project
     return;
   }
   for (let i = 0; i < children.length; i++) {
-    createDom(children[i], domNode, undefined, projectionOptions);
+    if (!children[i].domNode) {
+      createDom(children[i], domNode, undefined, projectionOptions);
+    } else {
+      initPropertiesAndChildren(children[i].domNode!, children[i], projectionOptions);
+    }
   }
 };
 


### PR DESCRIPTION
This PR allows a `VNode` with children be fully subsumed by the projector when there is already an assigned `domNode` on the `VNode`s.

Resolves #98 