### PR TITLE
Use the domNode from the vnode over creating if one is provided

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -781,7 +781,7 @@ createDom = function(vnode, parentNode, insertBefore, projectionOptions) {
           if (projectionOptions.namespace !== undefined) {
             domNode = vnode.domNode = doc.createElementNS(projectionOptions.namespace, found);
           } else {
-            domNode = vnode.domNode = doc.createElement(found);
+            domNode = vnode.domNode = (vnode.domNode || doc.createElement(found));
             if (found === 'input' && vnode.properties && vnode.properties.type !== undefined) {
               // IE8 and older don't support setting input type after the DOM Node has been added to the document
               (domNode as Element).setAttribute("type", vnode.properties.type);

--- a/test/dom/create.ts
+++ b/test/dom/create.ts
@@ -62,5 +62,16 @@ describe('dom', function() {
       }).to.throw(/may not be changed/);
     });
 
+    it('should allow an existing dom node to be used', () => {
+      const node = document.createElement('div');
+      (node as any).foo = 'bar';
+      const vnode = h('div', { id: 'id' });
+      vnode.domNode = node;
+      const projection = dom.create(vnode);
+      const root = projection.domNode as any;
+      expect(root.outerHTML).to.equal('<div id="id"></div>');
+      expect(root.foo).to.equal('bar');
+    });
+
   });
 });

--- a/test/projector.ts
+++ b/test/projector.ts
@@ -86,7 +86,6 @@ describe('Projector', () => {
     expect(renderFunction).to.have.been.calledThrice;
     expect(parentElement.removeChild).to.have.been.calledOnce;
     expect(parentElement.removeChild.lastCall.args[0]).to.equal(oldElement);
-    expect(parentElement.ownerDocument.createElement).to.have.been.calledThrice;
     expect(parentElement.insertBefore).to.have.been.calledTwice;
     expect(parentElement.insertBefore.lastCall.args[0]).to.deep.include({ tagName: 'DIV' });
     expect(parentElement.insertBefore.lastCall.args[1]).to.equal(oldElement);


### PR DESCRIPTION
We are finding scenario's where when we want to use existing libs that create their own dom nodes. I know we can use the `afterCreate` hook to get a handle on a wrapping node and append these external nodes manually, but then we are stuck with an arbitrary wrapping node which is not ideal (at the moment we are doing hackier things to avoid this like actually replacing the node via getting the parent and replacing the child).

It would be nice if maquette honoured the `domNode` property on a `vnode` during creation: ie if one was provided then use that over creating one. This would essentially give us `merge` like behaviour (https://github.com/AFASSoftware/maquette/pull/99) after the initial projection creation. This is advantageous, because the domnode is then semi-controlled by maquette, as in we can use `h` to write to it (while the external library still being able to affect it also, with the caveat that one knows nothing about the other state wise).