### PR TITLE
Remove merge specific re-use of dom nodes

### DIFF
--- a/src/maquette.ts
+++ b/src/maquette.ts
@@ -734,11 +734,7 @@ let addChildren = function(domNode: Node, children: VNode[] | undefined, project
     return;
   }
   for (let i = 0; i < children.length; i++) {
-    if (!children[i].domNode) {
       createDom(children[i], domNode, undefined, projectionOptions);
-    } else {
-      initPropertiesAndChildren(children[i].domNode!, children[i], projectionOptions);
-    }
   }
 };
 
@@ -789,7 +785,7 @@ createDom = function(vnode, parentNode, insertBefore, projectionOptions) {
           }
           if (insertBefore !== undefined) {
             parentNode.insertBefore(domNode, insertBefore);
-          } else {
+          } else if (domNode.parentNode !== parentNode) {
             parentNode.appendChild(domNode);
           }
         }

--- a/test/dom/create.ts
+++ b/test/dom/create.ts
@@ -1,4 +1,4 @@
-import {expect, jsdom} from '../utilities';
+import {expect, sinon, jsdom} from '../utilities';
 import {h, dom} from '../../src/maquette';
 
 describe('dom', function() {
@@ -64,13 +64,24 @@ describe('dom', function() {
 
     it('should allow an existing dom node to be used', () => {
       const node = document.createElement('div');
-      (node as any).foo = 'bar';
-      const vnode = h('div', { id: 'id' });
+      (node as any).foo = 'foo';
+      const childNode = document.createElement('span');
+      (childNode as any).bar = 'bar';
+      node.appendChild(childNode);
+      const spy = sinon.spy(node, 'appendChild');
+
+      const childVNode = h('span', { id: 'b' });
+      childVNode.domNode = childNode;
+      const vnode = h('div', { id: 'a' }, [ childVNode ]);
       vnode.domNode = node;
+
       const projection = dom.create(vnode);
       const root = projection.domNode as any;
-      expect(root.outerHTML).to.equal('<div id="id"></div>');
-      expect(root.foo).to.equal('bar');
+      expect(root.outerHTML).to.equal('<div id="a"><span id="b"></span></div>');
+      expect(root.foo).to.equal('foo');
+      expect(root.children[0].bar).to.equal('bar');
+      // should not append child again, if it has a parent that matches
+      expect(spy.called).to.be.false;
     });
 
   });

--- a/test/projector.ts
+++ b/test/projector.ts
@@ -1,5 +1,5 @@
 import {expect, sinon, jsdom} from './utilities';
-import {createProjector, h, Component} from '../src/maquette';
+import {createProjector, h, Component, VNode} from '../src/maquette';
 
 describe('Projector', () => {
 
@@ -97,43 +97,6 @@ describe('Projector', () => {
     expect(global.requestAnimationFrame).to.have.been.calledOnce;
     global.requestAnimationFrame.callArg(0);
     expect(renderFunction).to.have.callCount(6);
-  });
-
-  it('can reuse existing dom', () => {
-    let parentNode = {
-      tagName: 'DIV'
-    };
-    let childNode = {
-      onclick: function () { },
-      ownerDocument: {
-        createElement: sinon.spy((tag: string) => {
-          return document.createElement(tag);
-        })
-      },
-      tagName: 'SPAN',
-      textContent: undefined
-    };
-    let handleClick = sinon.stub();
-    let renderFunction = sinon.stub().returns({
-      vnodeSelector: 'div',
-      properties: {},
-      children: [ {
-        vnodeSelector: 'span',
-        properties: { onclick: handleClick },
-        children: undefined,
-        text: 'text',
-        domNode: childNode
-      } ],
-      text: undefined,
-      domNode: null
-    });
-    let projector = createProjector({});
-
-    projector.merge(parentNode as any, renderFunction);
-
-    childNode.onclick();
-    expect(handleClick).to.have.been.calledOnce;
-    expect(childNode.textContent).to.equal('text');
   });
 
   it('Can stop and resume', () => {


### PR DESCRIPTION
https://github.com/AFASSoftware/maquette/pull/99 partially conflicts with https://github.com/AFASSoftware/maquette/pull/103. The changes in #103 actually supersede the `merge` functionality anyway, as you can now re-use an existing dom node generically on any `VNode` regardless of projector attach types.

I have included an additional fix to only append the node if it's not already appended to the same parent node, otherwise this causes weird ordering issues when subsuming dom via an initial `merge`