### PR TITLE
Avoid polyfilling `Array.prototype.find`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@
  *
  * [[https://maquettejs.org/|To the maquette homepage]]
  */
-import './polyfills';
 export * from './interfaces';
 export { dom } from './dom';
 export { h } from './h';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,7 +1,0 @@
-// tslint:disable no-invalid-this
-// istanbul ignore next: Polyfill only needed for IE10 and IE11
-if (!Array.prototype.find) {
-  Array.prototype.find = function(predicate: any) {
-    return this.filter(predicate)[0];
-  };
-}

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -26,10 +26,12 @@ let createParentNodePath = (node: Node, rootNode: Element) => {
   return parentNodePath;
 };
 
+let find = <T>(items: T[], predicate: (item: T) => boolean) => items.filter(predicate)[0];
+
 let findVNodeByParentNodePath = (vnode: VNode, parentNodePath: Node[]): VNode | undefined => {
   let result: VNode | undefined = vnode;
   parentNodePath.forEach(node => {
-    result = (result && result.children) ? result.children!.find(child => child.domNode === node)! : undefined;
+    result = (result && result.children) ? find(result.children, child => child.domNode === node) : undefined;
   });
   return result;
 };


### PR DESCRIPTION
This is an alternative fix for https://github.com/AFASSoftware/maquette/issues/140:

* Avoids polyfilling, which should be left to clients, especially since it doesn't match [MDN's polyfill.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill)
* Shaves a few bytes from the raw distributable code (non-gzipped).