### PR TITLE
feat: allow passing non-event-handler functions to props

### DIFF
--- a/src/projection.ts
+++ b/src/projection.ts
@@ -196,8 +196,8 @@ let setProperties = (domNode: Node, properties: VNodeProperties | undefined, pro
             }());
             /* tslint:enable */
           }
-          (domNode as any)[propName] = propValue;
         }
+        (domNode as any)[propName] = propValue;
       } else if (projectionOptions.namespace === NAMESPACE_SVG) {
         if (propName === 'href') {
           (domNode as Element).setAttributeNS(NAMESPACE_XLINK, propName, propValue);

--- a/test/dom/properties-tests.ts
+++ b/test/dom/properties-tests.ts
@@ -223,6 +223,23 @@ describe('dom', () => {
       });
     });
 
+    it('allows passing functions to props', () => {
+      /* tslint:disable no-empty */
+      let someMethod = () => { };
+      /* tslint:enable no-empty */
+      let renderFunction = () => h('div', { nonEventFunctionProp: someMethod });
+      let projection = dom.create(renderFunction(), { eventHandlerInterceptor: noopEventHandlerInterceptor });
+
+      interface FakeCustomElement extends HTMLElement {
+        /* tslint:disable prefer-method-signature */
+        nonEventFunctionProp: () => void;
+        /* tslint:enable prefer-method-signature */
+      }
+
+      let fakeCustomElement = (projection.domNode as FakeCustomElement);
+      expect(fakeCustomElement.nonEventFunctionProp).to.equal(someMethod);
+    });
+
     it('updates the value property', () => {
       let typedKeys = '';
       let handleInput = (evt: Event) => {


### PR DESCRIPTION
This PR allows maquette to pass any function to a property. 

This is only allowed for properties following the `on<someEvent>` naming convention for event handlers, but with custom elements gaining popularity, there is no guarantee that all function properties will adhere to this convention. 

Currently, users can work around this by using the `afterCreate` callback to manually set the function property, but leads to unnecessary boilerplate.