### PR TITLE
Created an option to avoid automatically scheduling render on every event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maquette",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maquette",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/chai-as-promised": "7.1.8",

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -17,6 +17,7 @@ const DEFAULT_PROJECTION_OPTIONS: ProjectionOptions = {
       (domNode.style as any)[styleName] = value;
     }
   },
+  scheduleRenderAfterEvents: true,
 };
 
 export let applyDefaultProjectionOptions = (

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -378,6 +378,12 @@ export interface ProjectorOptions {
    * @param value     The value of this style, for example `rotate(45deg)`.
    */
   styleApplyer?(domNode: HTMLElement, styleName: string, value: string): void;
+
+  /**
+   * Should the projector schedule a render after capturing an event?
+   * Default to true.
+   */
+  scheduleRenderAfterEvents?: boolean;
 }
 
 export interface ProjectionOptions extends ProjectorOptions {


### PR DESCRIPTION
I use Maquette within a game engine that automatically renders on every frame, so I don't want Maquette scheduling its own renders on events. I considered creating a whole new Projector but that seemed like overkill for such a small change.

I added an option `scheduleRenderAfterEvents` to the projector that simply skips the call to `scheduleRender()` when false. The option defaults to true so that it shouldn't mess up existing code.

I'm not sure about how you want to name things, so please let me know...

PS: Thanks for this library, it's wonderful!

