### PR TITLE
Filter out VNode callbacks when populating the DOMNode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maquette",
-  "version": "4.0.2",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maquette",
-      "version": "4.0.2",
+      "version": "4.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai-as-promised": "7.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maquette",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Minimalistic Virtual DOM implementation with support for animated transitions.",
   "homepage": "https://maquettejs.org/",
   "keywords": [

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -154,6 +154,19 @@ let nodeToRemove = (vNode: VNode) => {
   }
 };
 
+const vnodeOnlyProps = [
+  "afterCreate",
+  "afterUpdate",
+  "afterRemoved",
+  "enterAnimation",
+  "exitAnimation",
+  "updateAnimation",
+];
+
+function filterVNodeOnlyProps(name: string): boolean {
+  return !vnodeOnlyProps.includes(name);
+}
+
 let setProperties = (
   domNode: Node,
   properties: VNodeProperties | undefined,
@@ -163,7 +176,7 @@ let setProperties = (
     return;
   }
   let eventHandlerInterceptor = projectionOptions.eventHandlerInterceptor;
-  let propNames = Object.keys(properties);
+  let propNames = Object.keys(properties).filter(filterVNodeOnlyProps);
   let propCount = propNames.length;
   for (let i = 0; i < propCount; i++) {
     let propName = propNames[i];
@@ -228,8 +241,8 @@ let setProperties = (
               };
             })();
           }
-          (domNode as any)[propName] = propValue;
         }
+        (domNode as any)[propName] = propValue;
       } else if (projectionOptions.namespace === NAMESPACE_SVG) {
         if (propName === "href") {
           (domNode as Element).setAttributeNS(NAMESPACE_XLINK, propName, propValue);
@@ -372,7 +385,8 @@ let updateProperties = (
     return;
   }
   let propertiesUpdated = false;
-  let propNames = Object.keys(properties);
+
+  let propNames = Object.keys(properties).filter(filterVNodeOnlyProps);
   let propCount = propNames.length;
   for (let i = 0; i < propCount; i++) {
     let propName = propNames[i];

--- a/test/dom/properties-tests.ts
+++ b/test/dom/properties-tests.ts
@@ -229,7 +229,7 @@ describe("dom", () => {
       });
     });
 
-    it("Does not allow passing functions to props since maquette 4.1", () => {
+    it("allows passing functions to props", () => {
       let someMethod = () => {
         /* noop */
       };
@@ -243,7 +243,16 @@ describe("dom", () => {
       }
 
       let fakeCustomElement = projection.domNode as FakeCustomElement;
-      expect(fakeCustomElement.nonEventFunctionProp).to.be.undefined;
+      expect(fakeCustomElement.nonEventFunctionProp).to.equal(someMethod);
+    });
+
+    it("does not add Maquette lifecycle functions to the DOM node", () => {
+      let renderFunction = () => h("div", { afterCreate: () => {} });
+      let projection = dom.create(renderFunction(), {
+        eventHandlerInterceptor: noopEventHandlerInterceptor,
+      });
+      let div = projection.domNode as HTMLDivElement;
+      expect("afterCreate" in div).to.be.false;
     });
 
     it("updates the value property", () => {


### PR DESCRIPTION
This reverts "No longer putting unneeded functions on DOM nodes, to facilitate garbage collection"