### PR TITLE
Migrate website from maquettejs.org to maquette.js.org

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,57 @@
+name: Deploy website to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Build library (needed for typedoc)
+        run: npm run dist
+
+      - name: Install website dependencies
+        working-directory: website
+        run: npm install --no-optional --force
+
+      - name: Build website
+        working-directory: website
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build/website
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Compared to other virtual DOM implementations, maquette has the following advant
 
 * It is very lightweight (3.7Kb gzipped)
 * It allows changes to be animated
-* It makes your frontend [easy to unit-test](https://maquettejs.org/docs/unit-testing.html)
+* It makes your frontend [easy to unit-test](https://maquette.js.org/docs/unit-testing.html)
 
-Visit the [website](https://maquettejs.org) for more information.
+Visit the [website](https://maquette.js.org) for more information.

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "maquette",
   "main": "dist/maquette.js",
   "version": "2.5.4",
-  "homepage": "http://maquettejs.org/",
+  "homepage": "https://maquette.js.org/",
   "authors": [
     "Johan Gorter <johan@johangorter.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "workspaces": [
     "browser-tests"
   ],
-  "homepage": "https://maquettejs.org/",
+  "homepage": "https://maquette.js.org/",
   "keywords": [
     "virtual",
     "dom",

--- a/src/h.ts
+++ b/src/h.ts
@@ -40,7 +40,7 @@ let appendChildren = (parentSelector: string, insertions: VNodeChild[], main: VN
  *
  * @returns           A VNode object, used to render a real DOM later.
  *
- * NOTE: There are {@link http://maquettejs.org/docs/rules.html two basic rules} you should be aware of when updating the virtual DOM.
+ * NOTE: There are {@link https://maquette.js.org/docs/rules.html two basic rules} you should be aware of when updating the virtual DOM.
  */
 export function h(
   selector: string,
@@ -60,7 +60,7 @@ export function h(
  *
  * @returns           A VNode object, used to render a real DOM later.
  *
- * NOTE: There are {@link http://maquettejs.org/docs/rules.html two basic rules} you should be aware of when updating the virtual DOM.
+ * NOTE: There are {@link https://maquette.js.org/docs/rules.html two basic rules} you should be aware of when updating the virtual DOM.
  */
 export function h(selector: string, children: VNodeChild[]): VNode;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * interactive web applications. To get started, use {@link createProjector} to create a projector
  * that manages the rendering lifecycle, and use the {@link h} function to create virtual DOM nodes.
  *
- * {@link https://maquettejs.org/ | ← Back to the maquette homepage}
+ * {@link https://maquette.js.org/ | ← Back to the maquette homepage}
  * @module
  */
 export { createCache } from "./cache";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -103,7 +103,7 @@ export interface VNode {
 export interface VNodeProperties {
   /**
    * The animation to perform when this node is added to an already existing parent.
-   * {@link http://maquettejs.org/docs/animations.html More about animations}.
+   * {@link https://maquette.js.org/docs/animations.html More about animations}.
    * @param element - Element that was just added to the DOM.
    * @param properties - The properties object that was supplied to the {@link h} method
    */
@@ -120,7 +120,7 @@ export interface VNodeProperties {
   /**
    * The animation to perform when the properties of this node change.
    * This also includes attributes, styles, css classes. This callback is also invoked when node contains only text and that text changes.
-   * {@link http://maquettejs.org/docs/animations.html More about animations}.
+   * {@link https://maquette.js.org/docs/animations.html More about animations}.
    * @param element - Element that was modified in the DOM.
    * @param properties - The last properties object that was supplied to the {@link h} method
    * @param previousProperties - The previous properties object that was supplied to the {@link h} method
@@ -166,7 +166,7 @@ export interface VNodeProperties {
   /**
    * Callback that is called when a node has been removed from the tree.
    * The callback is called during idle state or after a timeout (fallback).
-   * {@link https://maquettejs.org/docs/dom-node-removal.html More info}
+   * {@link https://maquette.js.org/docs/dom-node-removal.html More info}
    * @param element - The element that has been removed from the DOM.
    */
   afterRemoved?(element: Element): void;
@@ -402,7 +402,7 @@ export interface ProjectionOptions extends ProjectorOptions {
 
 /**
  * Keeps an array of result objects synchronized with an array of source objects.
- * See {@link http://maquettejs.org/docs/arrays.html Working with arrays}.
+ * See {@link https://maquette.js.org/docs/arrays.html Working with arrays}.
  *
  * Mapping provides a {@link map} function that updates its {@link results}.
  * The {@link map} function can be called multiple times and the results will get created, removed and updated accordingly.

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -2,7 +2,7 @@ import { Mapping } from "./interfaces";
 
 /**
  * Creates a {@link Mapping} instance that keeps an array of result objects synchronized with an array of source objects.
- * See {@link http://maquettejs.org/docs/arrays.html Working with arrays}.
+ * See {@link https://maquette.js.org/docs/arrays.html Working with arrays}.
  *
  * @param <Source>       The type of source items. A database-record for instance.
  * @param <Target>       The type of target items. A {@link MaquetteComponent} for instance.

--- a/website/firebase.json
+++ b/website/firebase.json
@@ -5,6 +5,13 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "redirects": [
+      {
+        "source": "/:path*",
+        "destination": "https://maquette.js.org/:path",
+        "type": 301
+      }
     ]
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maquette-website",
   "description": "Website for maquette",
-  "homepage": "https://maquettejs.org/",
+  "homepage": "https://maquette.js.org/",
   "version": "1.0.0",
   "author": "Johan Gorter <johan@johangorter.com>",
   "repository": {

--- a/website/source/CNAME
+++ b/website/source/CNAME
@@ -1,0 +1,1 @@
+maquette.js.org

--- a/website/source/script.js.ejs
+++ b/website/source/script.js.ejs
@@ -78,7 +78,7 @@ window.createLiveEditor = function (projector) {
         js_external: "//unpkg.com/maquette@<%-maquetteVersion-%>/dist/maquette.umd.js;" +
         "//cdnjs.cloudflare.com/ajax/libs/velocity/1.2.2/velocity.min.js;" +
         "//unpkg.com/maquette-css-transitions@1.1.0/dist/maquette-css-transitions.umd.js",
-        css_external: "//maquettejs.org/demo.css"
+        css_external: "//maquette.js.org/demo.css"
       })})
     ])).domNode.submit();
   };

--- a/website/source/tutorial/12-done.ejs
+++ b/website/source/tutorial/12-done.ejs
@@ -21,7 +21,7 @@ layout: tutorial.ejs
       <h1>Congratulations</h1>
       <h2>You completed the maquette tutorial!</h2>
       <a href="https://twitter.com/share" class="twitter-share-button"
-         data-url="https://maquettejs.org/tutorial/01-intro.html"
+         data-url="https://maquette.js.org/tutorial/01-intro.html"
          data-text="I completed the maquette virtual DOM tutorial"
          data-size="large" data-count="none" data-hashtags="maquettejs">Tweet</a>
       </p>


### PR DESCRIPTION
## Summary

Migrates the website domain from `maquettejs.org` to `maquette.js.org` (GitHub Pages via js.org).

### Changes

- **URL references**: Updated all `maquettejs.org` references to `maquette.js.org` across source code, docs, JSDoc comments, and website templates
- **HTTPS upgrade**: Upgraded remaining `http://` links to `https://`
- **Firebase redirect**: Added 301 redirect config in `firebase.json` so the old domain forwards all traffic path-preserving to the new domain
- **GitHub Pages CNAME**: Added `CNAME` file to website source for GitHub Pages custom domain

### Deployment order (zero downtime)

1. **Before merging**: Request `maquette.js.org` CNAME from [js.org/js.org](https://github.com/js-org/js.org) pointing to `afassoftware.github.io`
2. **Before merging**: Enable GitHub Pages on this repo and configure the custom domain
3. **Merge this PR** and deploy the website to GitHub Pages
4. **Deploy Firebase** (`cd website && firebase deploy`) to activate the 301 redirects from the old domain
5. **Keep** `maquettejs.org` on Firebase as a redirect host until the domain expires