### PR TITLE
fix: correct dual-package hazard in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "type": "git",
     "url": "https://github.com/AFASSoftware/maquette"
   },
-  "module": "./dist/index.js",
   "main": "./dist/maquette.cjs",
-  "browser": "./dist/maquette.umd.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -29,8 +27,7 @@
       "import": "./dist/index.js",
       "require": "./dist/maquette.cjs"
     },
-    "./package.json": "./package.json",
-    "./dist/*": "./dist/*"
+    "./package.json": "./package.json"
   },
   "scripts": {
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "import": "./dist/index.js",
       "require": "./dist/maquette.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
   },
   "scripts": {
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,18 @@
     "url": "https://github.com/AFASSoftware/maquette"
   },
   "module": "./dist/index.js",
-  "main": "./dist/maquette.cjs.js",
+  "main": "./dist/maquette.cjs",
   "browser": "./dist/maquette.umd.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "browser": "./dist/maquette.umd.js",
+      "import": "./dist/index.js",
+      "require": "./dist/maquette.cjs"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "prepare": "husky",
     "prepublishOnly": "npm run clean && npm run dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default [
     input: 'dist/index.js',
     output: {
       name: 'maquette',
-      file: pkg.browser,
+      file: pkg.exports['.'].browser,
       format: 'umd'
     },
     plugins: []


### PR DESCRIPTION
package.json declared "type": "module" but "main" still pointed to the
CommonJS build (dist/maquette.cjs.js). Because the file extension was
.js, Node/Vite parsed it as ESM despite its CommonJS content, causing
"ReferenceError: exports is not defined" in consumers.

Rename the CJS build output to dist/maquette.cjs (unambiguous
CommonJS regardless of "type": "module") and add an explicit exports
map so import/require resolve to the correct build.
